### PR TITLE
eco top placeholders

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/vault/VaultEcoHook.java
+++ b/src/main/java/com/extendedclip/papi/expansion/vault/VaultEcoHook.java
@@ -73,6 +73,8 @@ public class VaultEcoHook implements VaultHook {
       return fixMoney(getBalance(p));
     } else if (identifier.equals("balance_commas")) {
       return format.format(getBalance(p));
+    } else if (identifier.equals("top_rank")) {
+        return getTop(p.getPlayer().getName(), 1);
     } else if (identifier.startsWith("top_balance_fixed_")) {
       int rank = Integer.parseInt(identifier.split("top_balance_fixed_")[1]);
       return toLong(Double.parseDouble(getTop("bal", rank)));
@@ -150,6 +152,9 @@ public class VaultEcoHook implements VaultHook {
       } else if (balOrPlayer.equals("player")) {
         return String.valueOf(players.get(rank - 1));
       }
+    }
+    if (!balOrPlayer.equals("bal") && !balOrPlayer.equals("player"))  {
+        return String.valueOf(players.indexOf(balOrPlayer) + 1);
     }
     return "0";
   }

--- a/src/main/java/com/extendedclip/papi/expansion/vault/VaultEcoHook.java
+++ b/src/main/java/com/extendedclip/papi/expansion/vault/VaultEcoHook.java
@@ -79,6 +79,9 @@ public class VaultEcoHook implements VaultHook {
     } else if (identifier.startsWith("top_balance_formatted_")) {
       int rank = Integer.parseInt(identifier.split("top_balance_formatted_")[1]);
       return fixMoney(Double.parseDouble(getTop("bal", rank)));
+    } else if (identifier.startsWith("top_balance_commas")) {
+      int rank = Integer.parseInt(identifier.split("top_balance_commas_")[1]);
+      return format.format(Double.parseDouble(getTop("bal", rank)));
     } else if (identifier.startsWith("top_balance_")) {
       int rank = Integer.parseInt(identifier.split("top_balance_")[1]);
       return getTop("bal", rank);


### PR DESCRIPTION
Added:
```
%vault_eco_top_balance_#%
%vault_eco_top_balance_fixed_#%
%vault_eco_top_balance_formatted_#%
%vault_eco_top_balance_commas_#%
```
Requested by Frosty
```
%vault_eco_top_player_#%
%vault_eco_top_rank%
```
Requested by Trent

changed IF ELSEs to switch case makes code cleaner imo
tested all eco placeholders and all of them works fine (just in 1.12.2)
compiled version if u want to double check: http://aboodyy.net/PAPI-Expansion-Vault.jar