### PR TITLE
Checks if a player should be exluded from baltop

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/vault/BalTopTask.java
+++ b/src/main/java/com/extendedclip/papi/expansion/vault/BalTopTask.java
@@ -32,9 +32,11 @@ import org.bukkit.scheduler.BukkitRunnable;
 class BalTopTask extends BukkitRunnable {
 
   private final VaultEcoHook eco;
+  private final VaultPermsHook perms;
 
-  public BalTopTask(VaultEcoHook eco) {
+  public BalTopTask(VaultEcoHook eco, VaultPermsHook perms) {
     this.eco = eco;
+    this.perms = perms;
   }
 
   @Override
@@ -45,7 +47,9 @@ class BalTopTask extends BukkitRunnable {
       if (player == null || player.getName() == null) {
         continue;
       }
-      top.put(player.getName(), eco.getBalance(player));
+      if(!perms.hasPerm(player, "essentials.balancetop.exclude") || !Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
+        top.put(player.getName(), eco.getBalance(player));
+      }
     }
 
     eco.setBalTop(

--- a/src/main/java/com/extendedclip/papi/expansion/vault/VaultEcoHook.java
+++ b/src/main/java/com/extendedclip/papi/expansion/vault/VaultEcoHook.java
@@ -45,10 +45,12 @@ public class VaultEcoHook implements VaultHook {
   private final int topSize;
   private final Map<Integer, TopPlayer> balTop = new TreeMap<>();
   private Economy eco;
+  private VaultPermsHook perms;
   private BalTopTask balTopTask;
 
-  VaultEcoHook(VaultExpansion expansion) {
+  VaultEcoHook(VaultExpansion expansion, VaultPermsHook perms) {
     this.expansion = expansion;
+    this.perms = perms;
     baltopEnabled = (Boolean) expansion.get("baltop.enabled", true);
     topSize = expansion.getInt("baltop.cache_size", 100);
     taskDelay = expansion.getInt("baltop.check_delay", 30);
@@ -71,7 +73,7 @@ public class VaultEcoHook implements VaultHook {
     eco = rsp.getProvider();
 
     if (eco != null && baltopEnabled) {
-      this.balTopTask = new BalTopTask(this);
+      this.balTopTask = new BalTopTask(this, perms);
       balTopTask.runTaskTimerAsynchronously(expansion.getPlaceholderAPI(), 20, 20 * taskDelay);
     }
     return eco != null;

--- a/src/main/java/com/extendedclip/papi/expansion/vault/VaultExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/vault/VaultExpansion.java
@@ -36,7 +36,7 @@ public class VaultExpansion extends PlaceholderExpansion implements Cacheable, C
 
   public VaultExpansion() {
     perms = new VaultPermsHook();
-    eco = new VaultEcoHook(this);
+    eco = new VaultEcoHook(this, perms);
   }
 
   @Override


### PR DESCRIPTION
If a player has essentials.balancetop.exclude do not list them in baltop for placeholders. Fixes inconsistency between essentials baltop and placeholders. If Essentials is not installed the check is disabled.